### PR TITLE
Update viewer link to show both building and remote configuration identifier together

### DIFF
--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -96,13 +96,14 @@ class MapViewConfiguration {
 
   String _getViewerURL() {
     var base = _internalViewerDomain;
-    var query =
-        "apikey=$situmApiKey&domain=$_internalApiDomain&mode=embed&global=true";
-    if (remoteIdentifier != null) {
+    var query = "apikey=$situmApiKey&domain=$_internalApiDomain&mode=embed";
+
+    if (remoteIdentifier != null && buildingIdentifier != null) {
+      return "$base/id/$remoteIdentifier?$query&buildingid=$buildingIdentifier";
+    } else if (remoteIdentifier != null) {
       return "$base/id/$remoteIdentifier?$query";
     } else if (buildingIdentifier != null) {
-      query = "$query&buildingid=$buildingIdentifier";
-      return "$base/?$query";
+      return "$base/?$query&buildingid=$buildingIdentifier";
     }
     throw ArgumentError(
         'Missing configuration: remoteIdentifier or buildingIdentifier must be provided.');

--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -35,7 +35,7 @@ class MapViewConfiguration {
   final String? buildingIdentifier;
 
   /// A String identifier that allows you to remotely configure all map settings.
-  /// Alternatively you can pass a buildingIdentifier, but remoteIdentifier
+  /// Alternatively you can pass a buildingIdentifier, remoteIdentifier
   /// will be prioritized.
   final String? remoteIdentifier;
 


### PR DESCRIPTION
**Summary:**
To provide our integrators with a more flexible approach, this update allows the viewer link to display both building and remote details simultaneously when available.

**Changes:**

Updated the _getViewerURL method to construct URLs that can simultaneously contain both remoteIdentifier and buildingIdentifier.
Implemented checks to ensure the URL is correctly structured based on the provided identifiers.

**Benefits for Integrators:**

Integrators can now streamline their processes, leveraging a single URL that provides comprehensive details, eliminating the need to juggle between separate building and remote configuration identifier.

**Testing:**
All modifications have been locally tested to guarantee the URLs are formed correctly, and that the error handling mechanisms are robust.

We appreciate your feedback and hope this enhancement simplifies your integration process. Thanks for your attention!