### PR TITLE
Add device id as query param for map viewer

### DIFF
--- a/CHANGELOG_UNRELEASED.md
+++ b/CHANGELOG_UNRELEASED.md
@@ -1,0 +1,1 @@
+- The device id is added to the query params sent to the mapviewer.

--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -136,7 +136,7 @@ class MapViewConfiguration {
       query = "$query&lng=$language";
     }
     if (deviceId != null) {
-      query = "$query&device_id=$deviceId";
+      query = "$query&deviceId=$deviceId";
     }
 
     if (remoteIdentifier?.isNotEmpty == true &&

--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -126,7 +126,7 @@ class MapViewConfiguration {
     return finalApiDomain;
   }
 
-  String _getViewerURL() {
+  String _getViewerURL(String deviceId) {
     var base = viewerDomain;
     var query = "apikey=$situmApiKey&domain=$_internalApiDomain&mode=embed";
     if (lockCameraToBuilding != null) {
@@ -134,6 +134,9 @@ class MapViewConfiguration {
     }
     if (language != null) {
       query = "$query&lng=$language";
+    }
+    if (deviceId != null) {
+      query = "$query&device_id=$deviceId";
     }
 
     if (remoteIdentifier?.isNotEmpty == true &&

--- a/lib/src/situm_map_view.dart
+++ b/lib/src/situm_map_view.dart
@@ -144,14 +144,17 @@ class _MapViewState extends State<MapView> {
     _loadWithConfig(mapViewConfiguration);
   }
 
-  void _loadWithConfig(MapViewConfiguration configuration) {
+  void _loadWithConfig(MapViewConfiguration configuration) async {
     if (webViewController is AndroidWebViewController) {
       AndroidWebViewController.enableDebugging(configuration.enableDebugging);
     }
+
     if (webViewController is WebKitWebViewController) {
       (webViewController as WebKitWebViewController).setInspectable(configuration.enableDebugging);
     }
-    final String mapViewUrl = mapViewConfiguration._getViewerURL();
+    var sdk = SitumSdk();
+    final String deviceId = await sdk.getDeviceId();
+    final String mapViewUrl = mapViewConfiguration._getViewerURL(deviceId);
     // Load the composed URL in the WebView.
     webViewController
         ?.loadRequest(LoadRequestParams(uri: Uri.parse(mapViewUrl)));


### PR DESCRIPTION

- The device id is added to the query params sent to the mapviewer.