### PR TITLE
Hotfix/navigate to point

### DIFF
--- a/lib/src/sdk_mapper.dart
+++ b/lib/src/sdk_mapper.dart
@@ -160,15 +160,16 @@ SitumRoute createRoute(arguments) {
     Map map = arguments["poiTo"];
     poi = createPoi(map);
   }
-  return SitumRoute(rawContent: arguments,
-      poiTo: poi);
+  return SitumRoute(rawContent: arguments, poiTo: poi);
 }
 
 DirectionsRequest createDirectionsRequest(arguments) {
-  var poiToIdentifier = "";
+  var poiToIdentifier = null;
   Map directionsRequestArgs = arguments["directionsRequest"];
-  if (!directionsRequestArgs.containsKey("poiToIdentifier") && arguments["destinationCategory"] == "POI") {
-    poiToIdentifier =  stringFromArgsOrEmptyId(arguments, "destinationIdentifier");
+  if (!directionsRequestArgs.containsKey("poiToIdentifier") &&
+      arguments["destinationCategory"] == "POI") {
+    poiToIdentifier =
+        stringFromArgsOrEmptyId(arguments, "destinationIdentifier");
   }
   var directionsRequest = DirectionsRequest(
     from: createPoint(directionsRequestArgs["from"]),


### PR DESCRIPTION
Initialize `poiToIdentifier` to null, so `DirectionsRequest` `toMap` method does not generate this property in case the destination is not a POI